### PR TITLE
cli chat client won't be interrupted upon receiving messages

### DIFF
--- a/client.rb
+++ b/client.rb
@@ -1,18 +1,25 @@
 require 'socket'
+require 'readline'
 
 hostname = 'localhost'
 port = 8888
 
 s = TCPSocket.open(hostname, port)
 
+include Readline
+CLEAR_CUR_LINE = "\x1b[2K\x1b[0G"
+
+name = "YOU"
 
 Thread.new do
 	while msg = s.gets
-		puts msg
+        print CLEAR_CUR_LINE
+        puts "ANON: " + msg
+        print name + ": " + Readline.line_buffer
 	end
 end
 
 
 loop do
-	s.puts gets
+	s.puts readline(name + ": ", true)
 end


### PR DESCRIPTION
updated the receive code to:
wipe the current line using terminal magic
print the received message
print the stuff that was wiped

also uses YOU: and ANON: to match the gui client, they should be equiv now
